### PR TITLE
Add macOS ARM support and cross-platform build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 [Dd]ebugPublic/
 [Rr]elease/
 [Rr]eleases/
+[Pp]ublish/
 x64/
 x86/
 [Ww][Ii][Nn]32/

--- a/.gitignore
+++ b/.gitignore
@@ -92,5 +92,9 @@ PPTX-working/
 *.userosscache
 *.sln.docstates 
 
+# User-specific secrets
+secrets.json
+**/sign-macos-builds.env
+
 # Captured videos
 *.mkv

--- a/CaptureMode.cs
+++ b/CaptureMode.cs
@@ -28,6 +28,12 @@ public static class CaptureMode
 
     public static async Task<int> RunAsync()
     {
+        if (!OperatingSystem.IsWindows())
+        {
+            Console.WriteLine("Capture mode is only supported on Windows due to DirectShow dependencies.");
+            return 1;
+        }
+
         Console.WriteLine("\n\nUSB Capture - Direct to Disk");
         Console.WriteLine("============================\n\n");
 

--- a/FileManager.cs
+++ b/FileManager.cs
@@ -203,7 +203,7 @@ public static class FileManager
         else
         {
             Console.WriteLine("  ⚠ Some temporary files could not be cleaned up automatically");
-            Console.WriteLine("    Note: FFmpeg binaries are kept at C:\\ffmpeg for performance (reuse on next run)");
+            Console.WriteLine($"    Note: FFmpeg binaries are kept at {EmbeddedFFmpegRunner.GetPreferredFFmpegDirectory()} for performance (reuse on next run)");
         }
     }
 

--- a/PPTcrunch.csproj
+++ b/PPTcrunch.csproj
@@ -9,6 +9,8 @@
         <!-- Self-contained single file publishing configuration -->
         <PublishSingleFile>true</PublishSingleFile>
         <SelfContained>true</SelfContained>
+        <AssemblyName>pptcrunch</AssemblyName>
+        <RootNamespace>PPTcrunch</RootNamespace>
         <RuntimeIdentifiers>win-x64;osx-arm64</RuntimeIdentifiers>
         <PublishTrimmed>false</PublishTrimmed>
         <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>

--- a/PPTcrunch.csproj
+++ b/PPTcrunch.csproj
@@ -9,7 +9,7 @@
         <!-- Self-contained single file publishing configuration -->
         <PublishSingleFile>true</PublishSingleFile>
         <SelfContained>true</SelfContained>
-        <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+        <RuntimeIdentifiers>win-x64;osx-arm64</RuntimeIdentifiers>
         <PublishTrimmed>false</PublishTrimmed>
         <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
         <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>

--- a/QualityConfigService.cs
+++ b/QualityConfigService.cs
@@ -44,12 +44,12 @@ public class QualityConfigService
                     H264 = new CodecSettings
                     {
                         CPU = new EncodingSettings { Crf = 26, Preset = "medium" },
-                        GPU = new EncodingSettings { Cq = 26, Preset = "slow", Rc = rcMode, Tune = tuneMode, Multipass = multipassValue }
+                        GPU = new EncodingSettings { Cq = 26, VtQuality = 68, Preset = "slow", Rc = rcMode, Tune = tuneMode, Multipass = multipassValue }
                     },
                     H265 = new CodecSettings
                     {
                         CPU = new EncodingSettings { Crf = 25, Preset = "medium" },
-                        GPU = new EncodingSettings { Cq = 28, Preset = "slow", Rc = rcMode, Tune = tuneMode, Multipass = multipassValue }
+                        GPU = new EncodingSettings { Cq = 28, VtQuality = 62, Preset = "slow", Rc = rcMode, Tune = tuneMode, Multipass = multipassValue }
                     }
                 },
                 ["2"] = new QualityLevel
@@ -58,12 +58,12 @@ public class QualityConfigService
                     H264 = new CodecSettings
                     {
                         CPU = new EncodingSettings { Crf = 22, Preset = "medium" },
-                        GPU = new EncodingSettings { Cq = 22, Preset = "slow", Rc = rcMode, Tune = tuneMode, Multipass = multipassValue }
+                        GPU = new EncodingSettings { Cq = 22, VtQuality = 55, Preset = "slow", Rc = rcMode, Tune = tuneMode, Multipass = multipassValue }
                     },
                     H265 = new CodecSettings
                     {
                         CPU = new EncodingSettings { Crf = 24, Preset = "medium" },
-                        GPU = new EncodingSettings { Cq = 26, Preset = "slow", Rc = rcMode, Tune = tuneMode, Multipass = multipassValue }
+                        GPU = new EncodingSettings { Cq = 26, VtQuality = 50, Preset = "slow", Rc = rcMode, Tune = tuneMode, Multipass = multipassValue }
                     }
                 },
                 ["3"] = new QualityLevel
@@ -72,12 +72,12 @@ public class QualityConfigService
                     H264 = new CodecSettings
                     {
                         CPU = new EncodingSettings { Crf = 20, Preset = "slow" },
-                        GPU = new EncodingSettings { Cq = 20, Preset = "slow", Rc = rcMode, Tune = tuneMode, Multipass = multipassValue }
+                        GPU = new EncodingSettings { Cq = 20, VtQuality = 45, Preset = "slow", Rc = rcMode, Tune = tuneMode, Multipass = multipassValue }
                     },
                     H265 = new CodecSettings
                     {
                         CPU = new EncodingSettings { Crf = 22, Preset = "slow" },
-                        GPU = new EncodingSettings { Cq = 23, Preset = "slow", Rc = rcMode, Tune = tuneMode, Multipass = multipassValue }
+                        GPU = new EncodingSettings { Cq = 23, VtQuality = 42, Preset = "slow", Rc = rcMode, Tune = tuneMode, Multipass = multipassValue }
                     }
                 }
             },
@@ -239,6 +239,7 @@ public class EncodingSettings
 {
     public int? Crf { get; set; }
     public int? Cq { get; set; }
+    public int? VtQuality { get; set; }
     public string Preset { get; set; } = string.Empty;
     public string Rc { get; set; } = string.Empty;
     public string Tune { get; set; } = string.Empty;

--- a/README.md
+++ b/README.md
@@ -49,24 +49,35 @@ PPTcrunch is a .NET 8 console application that compresses videos using FFmpeg wi
 ### Building from Source
 
 1. **Clone or download** the source code
-2. **Build the executable** using the provided build script:
+2. **Build the executable** using the script for your platform:
 
-```batch
-publish.bat
-```
+   - **Windows**:
+
+     ```batch
+     publish.bat
+     ```
+
+   - **macOS (Apple silicon)**:
+
+     ```bash
+     ./publish.sh
+     ```
 
 - **Add to PATH** (recommended): Copy `publish\PPTcrunch.exe` to a directory in your system PATH
 - **Alternative**: Place `PPTcrunch.exe` in any directory and run with full path
 
 ### Using the Executable
 
-1. **First run**: The application will automatically download FFmpeg binaries to `C:\ffmpeg` (one-time only)
-2. **Subsequent runs**: FFmpeg binaries are reused from `C:\ffmpeg` for faster startup
-3. **Run**: Use `PPTcrunch.exe` from command line
+1. **First run**: The application will automatically download FFmpeg binaries to an OS-specific directory (Windows: `C:\ffmpeg`, macOS: `~/Library/Application Support/PPTcrunch/ffmpeg`).
+2. **Subsequent runs**: FFmpeg binaries are reused from that directory for faster startup.
+3. **Run**:
+   - Windows: `PPTcrunch.exe <file-pattern>`
+   - macOS: `./PPTcrunch <file-pattern>`
 
 ### Build Output Location
 
-- The build script outputs the executable to `publish\PPTcrunch.exe` in the repository root.
+- Windows builds output `publish\PPTcrunch.exe` in the repository root.
+- macOS builds output `publish/osx-arm64/PPTcrunch`.
 
 ### Adding PPTcrunch to PATH (Windows)
 
@@ -97,25 +108,20 @@ This program is distributed as a **self-contained executable** with **automatic 
 
 - ✅ **Single file**: Just `PPTcrunch.exe` - no external FFmpeg installation required
 - ✅ **Automatic FFmpeg**: Downloads and manages FFmpeg binaries automatically on first use
-- ✅ **Persistent storage**: FFmpeg binaries stored in `C:\ffmpeg` for reuse across sessions
+- ✅ **Persistent storage**: FFmpeg binaries stored in an OS-specific cache (`C:\ffmpeg` on Windows, `~/Library/Application Support/PPTcrunch/ffmpeg` on macOS) for reuse across sessions
 - ✅ **Auto-detection**: Detects NVIDIA NVENC availability and codec support; falls back to CPU automatically
 - ✅ **Hardware optimization**: Uses NVENC constant-quality mode (`-rc vbr` with `-b:v 0`) when available
 - ✅ **Quality mapping**: CPU CRF and GPU CQ are mapped to comparable visual quality per codec
-- ✅ **Windows focused**: Currently optimized for Windows x64 (see project configuration)
+- ✅ **Cross-platform builds**: Scripts provided for Windows x64 and macOS (Apple silicon) self-contained executables
 
 ## How to Use
 
-After building with `publish.bat`, use the executable:
+After building (`publish.bat` on Windows or `publish.sh` on macOS), run the executable from the publish directory:
 
-```bash
-PPTcrunch.exe <file-pattern>
-```
+- Windows: `PPTcrunch.exe <file-pattern>`
+- macOS: `./PPTcrunch <file-pattern>`
 
-Or start interactive USB capture (Windows DirectShow):
-
-```bash
-PPTcrunch.exe capture
-```
+Capture mode uses Windows-only DirectShow APIs and remains available as `PPTcrunch.exe capture` on Windows.
 
 ### Examples
 
@@ -313,7 +319,7 @@ Key parameters (dynamically set based on user choices):
 - XML reference updates are handled gracefully with warnings for any issues
 - All temporary directories are cleaned up even if errors occur
 - **Temporary Files**: The program creates and cleans up temporary directories (`PPT-temp` and `PPTX-working`) during processing
-- **FFmpeg Directory**: FFmpeg binaries are stored at `C:\ffmpeg` and are **intentionally preserved** between runs for performance (to avoid re-downloading)
+- **FFmpeg Directory**: FFmpeg binaries are stored in an OS-specific cache (`C:\ffmpeg` on Windows, `~/Library/Application Support/PPTcrunch/ffmpeg` on macOS) and are **intentionally preserved** between runs for performance (to avoid re-downloading)
 
 ## Supported Video Formats
 
@@ -329,14 +335,14 @@ Key parameters (dynamically set based on user choices):
 
 ## Requirements
 
-- Windows x64 with .NET 8 SDK (for building) or .NET 8 Runtime (for running)
+- Windows x64 or macOS (Apple silicon) with the .NET 8 SDK for building (self-contained builds include the runtime)
 - Internet connection for initial FFmpeg binary download (first run only)
 - Sufficient disk space for temporary files during processing
-- Write access to `C:\ffmpeg` directory (for FFmpeg binary storage)
+- Write access to the FFmpeg cache directory (`C:\ffmpeg` on Windows, `~/Library/Application Support/PPTcrunch/ffmpeg` on macOS)
 
 ## Troubleshooting
 
-1. **First run initialization**: On first use, the application will automatically download and initialize FFmpeg binaries to `C:\ffmpeg`
+1. **First run initialization**: On first use, the application will automatically download and initialize FFmpeg binaries to the cache directory (`C:\ffmpeg` on Windows, `~/Library/Application Support/PPTcrunch/ffmpeg` on macOS)
 2. **Permission errors**: Make sure you have write access to the directory containing the PPTX file
 3. **Large file processing**: Ensure sufficient disk space for temporary extraction and processing
 4. **GPU not being used**: The program will show NVENC availability during startup
@@ -349,7 +355,7 @@ Key parameters (dynamically set based on user choices):
    1. This usually happens when file handles are still open during cleanup
    2. The program will show warnings and provide the full paths for manual deletion
    3. Try closing any applications that might have the files open
-   4. The `C:\ffmpeg` directory is intentionally preserved for performance
+   4. The FFmpeg cache directory is intentionally preserved for performance
 
 ## Architecture
 

--- a/UserSettings.cs
+++ b/UserSettings.cs
@@ -7,6 +7,7 @@ public class UserSettings
     public int QualityLevel { get; set; } = 2; // 1=Smallest, 2=Balanced, 3=Highest quality
     public bool UseGPUAcceleration { get; set; } = true;
     public bool ReduceHighResTo1920 { get; set; } = true;
+    public HardwareAccelerationMode HardwareAcceleration { get; set; } = HardwareAccelerationMode.None;
 
     // Legacy property for backward compatibility
     public int Quality
@@ -44,11 +45,26 @@ public class UserSettings
 
     public string GetGpuCodecName()
     {
-        return Codec switch
+        return HardwareAcceleration switch
         {
-            VideoCodec.H264 => "h264_nvenc",
-            VideoCodec.H265 => "hevc_nvenc",
-            _ => "h264_nvenc"
+            HardwareAccelerationMode.AppleVideoToolbox => Codec switch
+            {
+                VideoCodec.H264 => "h264_videotoolbox",
+                VideoCodec.H265 => "hevc_videotoolbox",
+                _ => "h264_videotoolbox"
+            },
+            HardwareAccelerationMode.NvidiaNvenc => Codec switch
+            {
+                VideoCodec.H264 => "h264_nvenc",
+                VideoCodec.H265 => "hevc_nvenc",
+                _ => "h264_nvenc"
+            },
+            _ => Codec switch
+            {
+                VideoCodec.H264 => "h264_nvenc",
+                VideoCodec.H265 => "hevc_nvenc",
+                _ => "h264_nvenc"
+            }
         };
     }
 
@@ -80,4 +96,11 @@ public enum VideoCodec
 {
     H264 = 1,
     H265 = 2
+}
+
+public enum HardwareAccelerationMode
+{
+    None = 0,
+    NvidiaNvenc = 1,
+    AppleVideoToolbox = 2
 }

--- a/VideoProcessor.cs
+++ b/VideoProcessor.cs
@@ -105,7 +105,20 @@ public class VideoProcessor
 
         // Get actual quality value for filename
         var encodingSettings = QualityConfigService.GetEncodingSettings(settings.QualityLevel, settings.Codec, settings.UseGPUAcceleration);
-        int qualityValue = settings.UseGPUAcceleration ? (encodingSettings.Cq ?? 25) : (encodingSettings.Crf ?? 25);
+        int qualityValue;
+        if (settings.UseGPUAcceleration)
+        {
+            qualityValue = settings.HardwareAcceleration switch
+            {
+                HardwareAccelerationMode.AppleVideoToolbox => encodingSettings.VtQuality ?? encodingSettings.Cq ?? encodingSettings.Crf ?? 55,
+                HardwareAccelerationMode.NvidiaNvenc => encodingSettings.Cq ?? encodingSettings.VtQuality ?? encodingSettings.Crf ?? 25,
+                _ => encodingSettings.Crf ?? encodingSettings.Cq ?? encodingSettings.VtQuality ?? 25
+            };
+        }
+        else
+        {
+            qualityValue = encodingSettings.Crf ?? encodingSettings.Cq ?? encodingSettings.VtQuality ?? 25;
+        }
 
         // Generate codec string
         string codecString = settings.Codec == VideoCodec.H264 ? "H264" : "H265";

--- a/publish.bat
+++ b/publish.bat
@@ -17,13 +17,13 @@ echo Checking build results...
 echo.
 
 REM Check if build succeeded by verifying the executable exists
-if exist publish\PPTcrunch.exe (
+if exist publish\pptcrunch.exe (
     echo ========================================
     echo  Build completed successfully!
     echo ========================================
     echo.
     echo Single-file executable created:
-    echo publish\PPTcrunch.exe
+    echo publish\pptcrunch.exe
     echo.
     echo [OK] Single-file deployment ready
     echo [OK] No external dependencies required  

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PUBLISH_DIR="$SCRIPT_DIR/publish/osx-arm64"
+
+printf '\n========================================\n'
+printf ' PPTcrunch - macOS Release Publisher\n'
+printf '========================================\n\n'
+
+printf 'Building self-contained single file executable with embedded FFmpeg...\n'
+printf 'Target: macOS (Apple silicon, arm64) - no .NET runtime or FFmpeg installation required\n\n'
+
+rm -rf "$PUBLISH_DIR"
+mkdir -p "$PUBLISH_DIR"
+
+dotnet clean "$SCRIPT_DIR/PPTcrunch.csproj" --configuration Release > /dev/null
+
+dotnet publish "$SCRIPT_DIR/PPTcrunch.csproj" \
+    --configuration Release \
+    --runtime osx-arm64 \
+    --self-contained \
+    -p:PublishSingleFile=true \
+    -p:IncludeNativeLibrariesForSelfExtract=true \
+    -p:EnableCompressionInSingleFile=true \
+    -p:TrimMode=partial \
+    -p:PublishReadyToRun=true \
+    -o "$PUBLISH_DIR"
+
+printf '\nChecking build results...\n\n'
+
+if [[ -f "$PUBLISH_DIR/PPTcrunch" ]]; then
+    printf '========================================\n'
+    printf ' Build completed successfully!\n'
+    printf '========================================\n\n'
+    printf 'Single-file executable created:\n'
+    printf '  %s\n\n' "$PUBLISH_DIR/PPTcrunch"
+    printf '[OK] Single-file deployment ready\n'
+    printf '[OK] No external dependencies required\n'
+    printf '[OK] Embedded FFmpeg included - no external installation needed\n'
+    printf '[OK] Auto-detects NVIDIA GPU capabilities when available\n'
+    printf '[OK] Self-contained includes .NET 8 runtime\n\n'
+    printf 'Files in publish directory:\n'
+    ls -1 "$PUBLISH_DIR"
+    printf '\n'
+else
+    printf '========================================\n'
+    printf ' Build failed!\n'
+    printf '========================================\n\n'
+    printf 'Expected executable not found. Please check the error messages above.\n\n'
+    exit 1
+fi

--- a/publish.sh
+++ b/publish.sh
@@ -29,12 +29,12 @@ dotnet publish "$SCRIPT_DIR/PPTcrunch.csproj" \
 
 printf '\nChecking build results...\n\n'
 
-if [[ -f "$PUBLISH_DIR/PPTcrunch" ]]; then
+if [[ -f "$PUBLISH_DIR/pptcrunch" ]]; then
     printf '========================================\n'
     printf ' Build completed successfully!\n'
     printf '========================================\n\n'
     printf 'Single-file executable created:\n'
-    printf '  %s\n\n' "$PUBLISH_DIR/PPTcrunch"
+    printf '  %s\n\n' "$PUBLISH_DIR/pptcrunch"
     printf '[OK] Single-file deployment ready\n'
     printf '[OK] No external dependencies required\n'
     printf '[OK] Embedded FFmpeg included - no external installation needed\n'

--- a/publish.sh
+++ b/publish.sh
@@ -38,7 +38,7 @@ if [[ -f "$PUBLISH_DIR/PPTcrunch" ]]; then
     printf '[OK] Single-file deployment ready\n'
     printf '[OK] No external dependencies required\n'
     printf '[OK] Embedded FFmpeg included - no external installation needed\n'
-    printf '[OK] Auto-detects NVIDIA GPU capabilities when available\n'
+    printf '[OK] Auto-detects NVIDIA NVENC and Apple VideoToolbox hardware when available\n'
     printf '[OK] Self-contained includes .NET 8 runtime\n\n'
     printf 'Files in publish directory:\n'
     ls -1 "$PUBLISH_DIR"

--- a/sign-macos-builds.env.template
+++ b/sign-macos-builds.env.template
@@ -1,0 +1,16 @@
+# Copy this file to sign-macos-builds.env and fill in the Secrets
+# DO NOT commit sign-macos-builds.env to git: there should be a .gitignore entry for  `**/sign-macos-builds.env`
+
+# Your Developer ID Application certificate identifier
+# Get this by running: security find-identity -v -p codesigning
+# Look for the line containing "Developer ID Application" and use the string following the hex number (the hex is not the ID)
+export DEVELOPER_CERTIFICATE_ID="Developer ID Application: Brian Mathews (B8AYRC6X99)"
+
+# Your Apple ID email
+export APPLE_ID="your-email@icloud.com"
+
+# Your app-specific password
+export APPLE_ID_PASSWORD="your-app-specific-password"
+
+# Your Apple Developer Team ID
+export APPLE_TEAM_ID="B8AYRC6X99" 

--- a/sign-macos-builds.sh
+++ b/sign-macos-builds.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Signing macOS builds..."
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PUBLISH_SCRIPT="$SCRIPT_DIR/publish.sh"
+PUBLISH_DIR="$SCRIPT_DIR/publish/osx-arm64"
+BINARY_NAME="pptcrunch"
+BINARY_PATH="$PUBLISH_DIR/$BINARY_NAME"
+ENTITLEMENTS_FILE="$SCRIPT_DIR/${BINARY_NAME}.entitlements"
+ENV_FILE="$SCRIPT_DIR/sign-macos-builds.env"
+DISTRIBUTION_DIR="$SCRIPT_DIR/publish/distribution"
+ZIP_FOR_NOTARIZATION="$DISTRIBUTION_DIR/${BINARY_NAME}-macos.zip"
+FINAL_ZIP="$DISTRIBUTION_DIR/${BINARY_NAME}-macos-final.zip"
+README_FILE="$PUBLISH_DIR/README.txt"
+
+if [ -f "$ENV_FILE" ]; then
+    echo "Sourcing environment variables from $ENV_FILE"
+    # shellcheck source=/dev/null
+    source "$ENV_FILE"
+else
+    echo "Warning: Environment file $ENV_FILE not found"
+    echo "Will rely on environment variables already set"
+fi
+
+# Check for required environment variables
+if [ -z "${DEVELOPER_CERTIFICATE_ID:-}" ]; then
+    echo "Error: DEVELOPER_CERTIFICATE_ID environment variable is not set"
+    echo "Please set it with: export DEVELOPER_CERTIFICATE_ID='Developer ID Application: Your Name (XXXXXXXXXX)'"
+    exit 1
+fi
+
+if [ -z "${APPLE_ID:-}" ]; then
+    echo "Error: APPLE_ID environment variable is not set"
+    echo "Please set it with: export APPLE_ID='your.apple.id@example.com'"
+    exit 1
+fi
+
+if [ -z "${APPLE_ID_PASSWORD:-}" ]; then
+    echo "Error: APPLE_ID_PASSWORD environment variable is not set"
+    echo "Please set it with: export APPLE_ID_PASSWORD='your-app-specific-password'"
+    exit 1
+fi
+
+if [ -z "${APPLE_TEAM_ID:-}" ]; then
+    echo "Error: APPLE_TEAM_ID environment variable is not set"
+    echo "Please set it with: export APPLE_TEAM_ID='your-team-id'"
+    exit 1
+fi
+
+if [ ! -f "$BINARY_PATH" ]; then
+    if [ -x "$PUBLISH_SCRIPT" ]; then
+        echo "Published binary not found. Running publish script..."
+        "$PUBLISH_SCRIPT"
+    else
+        echo "Error: Published binary not found at $BINARY_PATH and publish script $PUBLISH_SCRIPT is not executable"
+        exit 1
+    fi
+fi
+
+if [ ! -f "$BINARY_PATH" ]; then
+    echo "Error: Published binary not found at $BINARY_PATH after running publish script"
+    exit 1
+fi
+
+echo "Preparing to sign $BINARY_PATH"
+ls -la "$BINARY_PATH"
+file "$BINARY_PATH"
+
+chmod +x "$BINARY_PATH"
+
+echo "Cleaning extended attributes..."
+xattr -cr "$BINARY_PATH"
+
+echo "Checking entitlements file..."
+if [ -f "$ENTITLEMENTS_FILE" ]; then
+    echo "Entitlements file found: $ENTITLEMENTS_FILE"
+    cat "$ENTITLEMENTS_FILE"
+else
+    echo "WARNING: Entitlements file not found at $ENTITLEMENTS_FILE"
+    echo "Codesign will continue without custom entitlements"
+fi
+
+echo "Checking certificate availability..."
+if ! security find-identity -v -p codesigning | grep -F "$DEVELOPER_CERTIFICATE_ID"; then
+    echo "ERROR: Certificate $DEVELOPER_CERTIFICATE_ID not found in keychain!"
+    echo "Available certificates:"
+    security find-identity -v -p codesigning
+    exit 1
+fi
+
+echo "Checking keychain access..."
+security list-keychains
+security default-keychain
+
+sign_binary() {
+    local apply_runtime="$1"
+    local runtime_flag=()
+
+    if [ "$apply_runtime" = "true" ]; then
+        runtime_flag=(-o runtime)
+        echo "Applying hardened runtime..."
+    else
+        echo "Attempting code signing without hardened runtime..."
+    fi
+
+    local sign_args=(
+        codesign
+        -s "$DEVELOPER_CERTIFICATE_ID"
+        -f
+        -v
+        --timestamp
+        "${runtime_flag[@]}"
+    )
+
+    if [ -f "$ENTITLEMENTS_FILE" ]; then
+        sign_args+=(--entitlements "$ENTITLEMENTS_FILE")
+    fi
+
+    sign_args+=("$BINARY_PATH")
+
+    if ! "${sign_args[@]}" 2>&1; then
+        if [ "$apply_runtime" = "true" ]; then
+            echo "WARNING: Could not apply hardened runtime"
+            return 1
+        fi
+
+        echo "ERROR: Code signing failed"
+        echo "This usually indicates certificate or keychain issues"
+        exit 1
+    fi
+
+    if [ "$apply_runtime" = "true" ]; then
+        echo "Hardened runtime applied successfully"
+    else
+        echo "Code signing without hardened runtime succeeded"
+    fi
+
+    return 0
+}
+
+sign_binary "false"
+if ! sign_binary "true"; then
+    echo "Continuing without hardened runtime. Notarization may fail without it."
+fi
+
+echo "Verifying signature..."
+codesign -v --deep --strict --verbose=2 "$BINARY_PATH"
+
+if ! codesign -d --entitlements - "$BINARY_PATH" 2>/dev/null; then
+    echo "No entitlements embedded in binary"
+fi
+
+mkdir -p "$DISTRIBUTION_DIR"
+
+cat > "$README_FILE" <<EOL
+pptcrunch for macOS
+
+Installation:
+1. Copy $BINARY_NAME to any directory (e.g., ~/bin or /usr/local/bin)
+2. Make sure the directory is in your PATH
+3. Run the program by typing: $BINARY_NAME [options]
+
+For help with command-line options:
+   $BINARY_NAME --help
+
+Note: You may need to run 'chmod +x $BINARY_NAME' after copying to a new location.
+EOL
+
+echo "Creating ZIP archive for notarization..."
+ditto -c -k --keepParent "$BINARY_PATH" "$ZIP_FOR_NOTARIZATION"
+
+echo "Submitting build for notarization..."
+SUBMISSION_OUTPUT=$(xcrun notarytool submit "$ZIP_FOR_NOTARIZATION" \
+    --apple-id "$APPLE_ID" \
+    --password "$APPLE_ID_PASSWORD" \
+    --team-id "$APPLE_TEAM_ID" \
+    --wait)
+
+echo "Notarization result:"
+echo "$SUBMISSION_OUTPUT"
+
+SUBMISSION_ID=$(echo "$SUBMISSION_OUTPUT" | grep "id:" | head -1 | awk '{print $2}')
+if [ -n "$SUBMISSION_ID" ]; then
+    echo "Retrieving notarization log for submission $SUBMISSION_ID..."
+    xcrun notarytool log "$SUBMISSION_ID" \
+        --apple-id "$APPLE_ID" \
+        --password "$APPLE_ID_PASSWORD" \
+        --team-id "$APPLE_TEAM_ID" || echo "Could not retrieve notarization log"
+else
+    echo "Could not extract notarization submission ID"
+fi
+
+echo "Creating final distribution package..."
+rm -f "$FINAL_ZIP"
+(
+    cd "$PUBLISH_DIR"
+    zip -r "$FINAL_ZIP" "$BINARY_NAME" "$(basename "$README_FILE")"
+)
+
+echo "Signing and notarization complete!"
+echo "Distribution packages are available in: $DISTRIBUTION_DIR"
+echo "- Notarization upload: $ZIP_FOR_NOTARIZATION"
+echo "- Final user package: $FINAL_ZIP"

--- a/sign-macos-builds.sh
+++ b/sign-macos-builds.sh
@@ -78,8 +78,7 @@ if [ -f "$ENTITLEMENTS_FILE" ]; then
     echo "Entitlements file found: $ENTITLEMENTS_FILE"
     cat "$ENTITLEMENTS_FILE"
 else
-    echo "WARNING: Entitlements file not found at $ENTITLEMENTS_FILE"
-    echo "Codesign will continue without custom entitlements"
+    echo "No custom entitlements file found - CLI programs typically don't require special entitlements"
 fi
 
 echo "Checking certificate availability..."
@@ -111,8 +110,12 @@ sign_binary() {
         -f
         -v
         --timestamp
-        "${runtime_flag[@]}"
     )
+    
+    # Add runtime flag only if it's not empty
+    if [ ${#runtime_flag[@]} -gt 0 ]; then
+        sign_args+=("${runtime_flag[@]}")
+    fi
 
     if [ -f "$ENTITLEMENTS_FILE" ]; then
         sign_args+=(--entitlements "$ENTITLEMENTS_FILE")


### PR DESCRIPTION
## Summary
- update the project configuration and FFmpeg bootstrapper to locate binaries on both Windows and macOS while keeping the Windows workflow intact
- add a macOS Apple silicon publish script and documentation covering the new multi-platform build outputs and cache locations
- guard Windows-only capture mode entry points and reuse the shared FFmpeg directory helper in user messaging

## Testing
- dotnet build *(fails: `dotnet` CLI not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccdfe69aec832aa830792bb86b47de